### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![SwiftDelayer](/Art/swiftDelayerBanner.png)
-[![Build Status](https://travis-ci.org/PiXeL16/SwiftDelayer.svg?branch=master)](https://travis-ci.org/PiXeL16/SwiftDelayer/) [![codecov.io](https://codecov.io/github/PiXeL16/SwiftDelayer/coverage.svg?branch=master)](https://codecov.io/github/PiXeL16/SwiftDelayer?branch=master) [![Cocoapods Compatible](https://img.shields.io/cocoapods/v/SwiftDelayer.svg)](https://img.shields.io/cocoapods/v/SwiftDelayer.svg) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/PiXeL16/SwiftDelayer/master/LICENSE)
+[![Build Status](https://travis-ci.org/PiXeL16/SwiftDelayer.svg?branch=master)](https://travis-ci.org/PiXeL16/SwiftDelayer/) [![codecov.io](https://codecov.io/github/PiXeL16/SwiftDelayer/coverage.svg?branch=master)](https://codecov.io/github/PiXeL16/SwiftDelayer?branch=master) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/SwiftDelayer.svg)](https://img.shields.io/cocoapods/v/SwiftDelayer.svg) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/PiXeL16/SwiftDelayer/master/LICENSE)
 
 # Swift Delayer
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
